### PR TITLE
s2idepix-27-only-use-hillshade-mountain-shadow

### DIFF
--- a/idepix-s2msi/src/main/java/org/esa/snap/idepix/s2msi/S2IdepixPostProcessOp.java
+++ b/idepix-s2msi/src/main/java/org/esa/snap/idepix/s2msi/S2IdepixPostProcessOp.java
@@ -103,7 +103,12 @@ public class S2IdepixPostProcessOp extends Operator {
             input.put("l1cProduct", l1cProduct);
             input.put("s2ClassifProduct", s2ClassifProduct);
             Map<String, Object> params = new HashMap<>();
-            params.put("computeMountainShadow", computeMountainShadow);
+            // we have decided not to use the mountain shadow as implemented in
+            // to include it again
+            //      - set the value to computeMountainShadow, change
+            //      - add || computeMountainShadow to the condition above
+            //      - consider the flag results in computeTile
+            params.put("computeMountainShadow", false);
             params.put("mode", mode);
             params.put("cwThresh", cwThresh);
             params.put("gclThresh", gclThresh);
@@ -168,7 +173,6 @@ public class S2IdepixPostProcessOp extends Operator {
         if (computeCloudShadow) {
             final Tile flagTile = getSourceTile(cloudShadowFlagBand, targetRectangle);
             int clusteredCloudShadowFlag = (int) Math.pow(2, S2IdepixPreCloudShadowOp.F_CLOUD_SHADOW); //clustering algorithm
-            int mountainShadowFlag = (int) Math.pow(2, S2IdepixPreCloudShadowOp.F_MOUNTAIN_SHADOW);
             int cloudBufferFlag = (int) Math.pow(2, S2IdepixPreCloudShadowOp.F_CLOUD_BUFFER);
             int potentialShadowFlag = (int) Math.pow(2, S2IdepixPreCloudShadowOp.F_POTENTIAL_CLOUD_SHADOW);
             int recommendedCloudShadow = (int) Math.pow(2, S2IdepixPreCloudShadowOp.F_RECOMMENDED_CLOUD_SHADOW);
@@ -187,10 +191,6 @@ public class S2IdepixPostProcessOp extends Operator {
                     }
                     if ((flagValue & clusteredCloudShadowFlag) == clusteredCloudShadowFlag) {
                         targetTile.setSample(x, y, S2IdepixConstants.IDEPIX_CLUSTERED_CLOUD_SHADOW, true);
-                    }
-
-                    if (computeMountainShadow && (flagValue & mountainShadowFlag) == mountainShadowFlag) {
-                        targetTile.setSample(x, y, S2IdepixConstants.IDEPIX_MOUNTAIN_SHADOW, true);
                     }
                 }
             }


### PR DESCRIPTION
Solves #27 . Actually, it doesn't, as the issue is abit broader and also encompasses the olci idepix. This PR is only about the s2 idepix. I have intentionally left in the implementation of the relative path algorithm, as the decision was not to remove it, but not to use it any longer. Also, the decision on which algorithm to use in the end is still outstanding.