### PR TITLE
Toniof idepix44 aiobe

### DIFF
--- a/idepix-s2msi/src/main/java/org/esa/snap/idepix/s2msi/operators/cloudshadow/FindContinuousAreas.java
+++ b/idepix-s2msi/src/main/java/org/esa/snap/idepix/s2msi/operators/cloudshadow/FindContinuousAreas.java
@@ -120,8 +120,8 @@ class FindContinuousAreas {
                 }
             }
             //test in all four next neighbours, from top left to bottom right (reversed to the iterations before)
-            for (int j = 1; j < sourceHeight - 1; j++) {
-                for (int i = 1; i < sourceWidth - 1; i++) {
+            for (int j = 1; j < sourceHeight - 2; j++) {
+                for (int i = 1; i < sourceWidth - 2; i++) {
                     int index = j * (sourceWidth) + i;
                     if (isTarget(index, useFlagBand)) {
                         int lowerNeighbour = cloudIdArray[index + sourceWidth];
@@ -163,7 +163,17 @@ class FindContinuousAreas {
                     int rightNeighbour = cloudIdArray[index1 + 1];
                     int center = cloudIdArray[index1];
 
-                    if (j == 0) {
+                    if (sourceHeight == 1) {
+                        int thisMax = rightNeighbour;
+                        if (center > thisMax) thisMax = center;
+                        if (center < thisMax) {
+                            cloudIdArray[index1] = thisMax;
+                            count++;
+                        } else if (rightNeighbour > 0 && rightNeighbour < thisMax) {
+                            cloudIdArray[index1 + 1] = thisMax;
+                            count++;
+                        }
+                    } else if (j == 0 && sourceHeight > 1) {
                         int lowerNeighbour = cloudIdArray[index1 + sourceWidth];
 
                         int thisMax = lowerNeighbour;
@@ -180,7 +190,7 @@ class FindContinuousAreas {
                             cloudIdArray[index1 + sourceWidth] = thisMax;
                             count++;
                         }
-                    } else if (j == sourceHeight - 1) {
+                    } else if (j == sourceHeight - 1 && sourceHeight > 1) {
                         int upperNeighbour = cloudIdArray[index1 - sourceWidth];
 
                         int thisMax = upperNeighbour;
@@ -224,7 +234,17 @@ class FindContinuousAreas {
                 if (isTarget(index2, useFlagBand)) {
                     int leftNeighbour = cloudIdArray[index2 - 1];
                     int center = cloudIdArray[index2];
-                    if (j == 0) {
+                    if (sourceHeight == 1) {
+                        int thisMax = leftNeighbour;
+                        if (center > thisMax) thisMax = center;
+                        if (center < thisMax) {
+                            cloudIdArray[index2] = thisMax;
+                            count++;
+                        } else if (leftNeighbour > 0 && leftNeighbour < thisMax) {
+                            cloudIdArray[index2 - 1] = thisMax;
+                            count++;
+                        }
+                    } else if (j == 0) {
                         int lowerNeighbour = cloudIdArray[index2 + sourceWidth];
 
                         int thisMax = lowerNeighbour;

--- a/idepix-s2msi/src/main/java/org/esa/snap/idepix/s2msi/operators/cloudshadow/PotentialCloudShadowAreaIdentifier.java
+++ b/idepix-s2msi/src/main/java/org/esa/snap/idepix/s2msi/operators/cloudshadow/PotentialCloudShadowAreaIdentifier.java
@@ -126,7 +126,7 @@ class PotentialCloudShadowAreaIdentifier {
         }
 
         if (cloudPath.length < 3) {
-            logger.warning("identifyPotentialCloudShadowPLUS: cloudPath.length=" + cloudPath.length);
+            logger.fine("identifyPotentialCloudShadowPLUS: cloudPath.length=" + cloudPath.length);
             return;
         }
 

--- a/idepix-s2msi/src/main/java/org/esa/snap/idepix/s2msi/operators/cloudshadow/PotentialCloudShadowAreaIdentifier.java
+++ b/idepix-s2msi/src/main/java/org/esa/snap/idepix/s2msi/operators/cloudshadow/PotentialCloudShadowAreaIdentifier.java
@@ -48,11 +48,15 @@ class PotentialCloudShadowAreaIdentifier {
             //start at lower left (not necessary, direction of search is appointed in identifyPotentialCloudShadow)
             yOffset = targetRectangle.y - sourceRectangle.y;
         }
-        for (i = xOffset; i < sourceWidth; i++) {
-            for (int j = yOffset; j < sourceHeight; j++) {
-                identifyPotentialCloudShadowPLUS(i, j, sourceHeight, sourceWidth, cloudPath, sourceLongitude,
-                        sourceLatitude, sourceAltitude, flagArray, sunZenithCloudRad,
-                        cloudIDArray, indexToPositions, offsetAtPositions);
+        if (cloudPath.length < 3) {
+            logger.fine("identifyPotentialCloudShadowPLUS: cloudPath.length=" + cloudPath.length);
+        } else {
+            for (i = xOffset; i < sourceWidth; i++) {
+                for (int j = yOffset; j < sourceHeight; j++) {
+                    identifyPotentialCloudShadowPLUS(i, j, sourceHeight, sourceWidth, cloudPath, sourceLongitude,
+                            sourceLatitude, sourceAltitude, flagArray, sunZenithCloudRad,
+                            cloudIDArray, indexToPositions, offsetAtPositions);
+                }
             }
         }
 
@@ -122,11 +126,6 @@ class PotentialCloudShadowAreaIdentifier {
         int index0 = y0 * width + x0;
         //start from a cloud pixel, otherwise stop.
         if (!((flagArray[index0] & PreparationMaskBand.CLOUD_FLAG) == PreparationMaskBand.CLOUD_FLAG)) {
-            return;
-        }
-
-        if (cloudPath.length < 3) {
-            logger.fine("identifyPotentialCloudShadowPLUS: cloudPath.length=" + cloudPath.length);
             return;
         }
 

--- a/idepix-s2msi/src/main/java/org/esa/snap/idepix/s2msi/operators/cloudshadow/S2IdepixCloudShadowOp.java
+++ b/idepix-s2msi/src/main/java/org/esa/snap/idepix/s2msi/operators/cloudshadow/S2IdepixCloudShadowOp.java
@@ -4,7 +4,11 @@ import com.bc.ceres.core.ProgressMonitor;
 import com.sun.media.jai.util.SunTileCache;
 import org.esa.snap.core.datamodel.CrsGeoCoding;
 import org.esa.snap.core.datamodel.GeoCoding;
+import org.esa.snap.core.datamodel.GeoPos;
+import org.esa.snap.core.datamodel.PixelPos;
 import org.esa.snap.core.datamodel.Product;
+import org.esa.snap.core.datamodel.RasterDataNode;
+import org.esa.snap.core.datamodel.StxFactory;
 import org.esa.snap.core.gpf.GPF;
 import org.esa.snap.core.gpf.Operator;
 import org.esa.snap.core.gpf.OperatorException;
@@ -18,6 +22,8 @@ import org.esa.snap.core.gpf.internal.OperatorImage;
 import org.esa.snap.core.gpf.internal.OperatorImageTileStack;
 import org.esa.snap.core.image.VectorDataMaskOpImage;
 import org.esa.snap.core.util.SystemUtils;
+import org.esa.snap.core.util.math.MathUtils;
+import org.esa.snap.idepix.s2msi.util.S2IdepixConstants;
 import org.opengis.referencing.operation.MathTransform;
 
 import javax.media.jai.CachedTile;
@@ -104,9 +110,17 @@ public class S2IdepixCloudShadowOp extends Operator {
 
         Product classificationProduct = getClassificationProduct(sourceResolution);
 
+        float sunZenithMean = getGeometryMean(classificationProduct, S2IdepixConstants.SUN_ZENITH_BAND_NAME);
+        float sunAzimuthMean = getGeometryMean(classificationProduct, S2IdepixConstants.SUN_AZIMUTH_BAND_NAME);
+        float viewZenithMean = getGeometryMean(classificationProduct, S2IdepixConstants.VIEW_ZENITH_BAND_NAME);
+        float viewAzimuthMean = getGeometryMean(classificationProduct, S2IdepixConstants.VIEW_AZIMUTH_BAND_NAME);
+        sunAzimuthMean = convertToApparentSunAzimuth(sunAzimuthMean, viewZenithMean, viewAzimuthMean);
+
         HashMap<String, Product> preInput = new HashMap<>();
         preInput.put("s2ClassifProduct", classificationProduct);
         Map<String, Object> preParams = new HashMap<>();
+        preParams.put("sunZenithMean", sunZenithMean);
+        preParams.put("sunAzimuthMean", sunAzimuthMean);
 
         //todo: test resolution of granule. Resample necessary bands to 60m. calculate cloud shadow on 60m.
         //todo: let mountain shadow benefit from higher resolution in DEM. Adjust sun zenith according to smoothing.
@@ -152,6 +166,8 @@ public class S2IdepixCloudShadowOp extends Operator {
         postParams.put("computeMountainShadow", computeMountainShadow);
         postParams.put("bestOffset", bestOffset);
         postParams.put("mode", mode);
+        postParams.put("sunZenithMean", sunZenithMean);
+        postParams.put("sunAzimuthMean", sunAzimuthMean);
         //put in here any parameters that might be requested by the post-processing operator
 
         //
@@ -163,6 +179,37 @@ public class S2IdepixCloudShadowOp extends Operator {
         setTargetProduct(prepareTargetProduct(sourceResolution, postProduct));
     }
 
+    private float getGeometryMean(Product classificationProduct, String rdnName) {
+        // the author of these lines is aware that at no point the mean is computed,
+        // for historic reasons we will stick to the name, though
+        RasterDataNode node = classificationProduct.getRasterDataNode(rdnName);
+        float mean = getRasterNodeValueAtCenter(node, classificationProduct.getSceneRasterWidth(),
+                classificationProduct.getSceneRasterHeight());
+        if (Float.isNaN(mean)) {
+            mean = (float) new StxFactory().create(node, ProgressMonitor.NULL).getMedian();
+        }
+        return mean;
+    }
+
+    private float getRasterNodeValueAtCenter(RasterDataNode var, int width, int height) {
+        return var.getSampleFloat((int) (0.5 * width), (int) (0.5 * height));
+    }
+
+    private float convertToApparentSunAzimuth(float sunAzimuthMean, float viewZenithMean, float viewAzimuthMean) {
+        // here: cloud path is calculated for center pixel sunZenith and sunAzimuth.
+        // after correction of sun azimuth angle into apparent sun azimuth angle.
+        // Due to projection of the cloud at view_zenith>0 the position of the cloud becomes distorted.
+        // The true position still causes the shadow - and it cannot be determined without the cloud top height.
+        // So instead, the apparent sun azimuth angle is calculated and used to find the cloudShadowRelativePath.
+
+        double diff_phi = sunAzimuthMean - viewAzimuthMean;
+        if (diff_phi < 0) diff_phi = 180 + diff_phi;
+        if (diff_phi > 90) diff_phi = diff_phi - 90;
+        diff_phi = diff_phi * Math.tan(viewZenithMean * MathUtils.DTOR);
+        if (viewAzimuthMean > 180) diff_phi = -1. * diff_phi;
+        return (float) (sunAzimuthMean + diff_phi);
+    }
+
     private int determineSourceResolution(Product product) throws OperatorException {
         final GeoCoding sceneGeoCoding = product.getSceneGeoCoding();
         if (sceneGeoCoding instanceof CrsGeoCoding) {
@@ -172,6 +219,34 @@ public class S2IdepixCloudShadowOp extends Operator {
             }
         }
         throw new OperatorException("Invalid product");
+    }
+
+    public static double determineResolution(Product product) {
+        int width = product.getSceneRasterWidth();
+        int height = product.getSceneRasterHeight();
+        GeoPos geoPos1 = product.getSceneGeoCoding().getGeoPos(new PixelPos(width / 2, 0), null);
+        GeoPos geoPos2 = product.getSceneGeoCoding().getGeoPos(new PixelPos(width / 2, height - 1), null);
+        double deltaLatInMeters = (geoPos1.lat - geoPos2.lat) / (height-1) / 180.0 * 6367500 * Math.PI;
+        double deltaLonInMeters = (geoPos1.lon - geoPos2.lon) / (height-1) / 180.0 * 6367500 * Math.PI * Math.cos((geoPos1.lat + geoPos2.lat) / 2 / 180 * Math.PI);
+        double resolution = (int) Math.round(Math.sqrt(deltaLatInMeters * deltaLatInMeters + deltaLonInMeters * deltaLonInMeters));
+        SystemUtils.LOG.info("Determined resolution as " + resolution + " m");
+        return resolution;
+    }
+
+    public static void getPixels(GeoCoding sceneGeoCoding,
+                                 final int x1, final int y1, final int w, final int h,
+                                 final float[] latPixels, final float[] lonPixels) {
+        PixelPos pixelPos = new PixelPos();
+        GeoPos geoPos = new GeoPos();
+        int i = 0;
+        for (int y = y1; y < y1 + h; ++y) {
+            for (int x = x1; x < x1 + w; ++x) {
+                pixelPos.setLocation(x + 0.5f, y + 0.5f);
+                sceneGeoCoding.getGeoPos(pixelPos, geoPos);
+                lonPixels[i] = (float) geoPos.lon;
+                latPixels[i++] = (float) geoPos.lat;
+            }
+        }
     }
 
     private Product getClassificationProduct(int resolution) {

--- a/idepix-s2msi/src/main/java/org/esa/snap/idepix/s2msi/operators/cloudshadow/S2IdepixCloudShadowOp.java
+++ b/idepix-s2msi/src/main/java/org/esa/snap/idepix/s2msi/operators/cloudshadow/S2IdepixCloudShadowOp.java
@@ -307,9 +307,9 @@ public class S2IdepixCloudShadowOp extends Operator {
             i++;
         }
         if (lx == 0) {
-            logger.warning("indecesRelativMaxInArray x.length=" + lx);
+            logger.fine("indecesRelativMaxInArray x.length=" + lx);
         } else if (lx == 1) {
-            logger.warning("indecesRelativMaxInArray x.length=" + lx);
+            logger.fine("indecesRelativMaxInArray x.length=" + lx);
             ID.add(0);
         } else if (valid) {
             double fac = -1.;

--- a/idepix-s2msi/src/main/java/org/esa/snap/idepix/s2msi/operators/cloudshadow/S2IdepixPostCloudShadowOp.java
+++ b/idepix-s2msi/src/main/java/org/esa/snap/idepix/s2msi/operators/cloudshadow/S2IdepixPostCloudShadowOp.java
@@ -23,6 +23,7 @@ import org.esa.snap.core.gpf.annotations.TargetProduct;
 import org.esa.snap.core.util.ProductUtils;
 import org.esa.snap.core.util.BitSetter;
 import org.esa.snap.core.util.math.MathUtils;
+import org.esa.snap.idepix.s2msi.util.S2IdepixConstants;
 import org.opengis.referencing.operation.MathTransform;
 
 import javax.media.jai.BorderExtenderConstant;

--- a/idepix-s2msi/src/main/java/org/esa/snap/idepix/s2msi/operators/cloudshadow/S2IdepixPreCloudShadowOp.java
+++ b/idepix-s2msi/src/main/java/org/esa/snap/idepix/s2msi/operators/cloudshadow/S2IdepixPreCloudShadowOp.java
@@ -16,6 +16,7 @@ import org.esa.snap.core.gpf.OperatorException;
 import org.esa.snap.core.gpf.OperatorSpi;
 import org.esa.snap.core.gpf.Tile;
 import org.esa.snap.core.gpf.annotations.OperatorMetadata;
+import org.esa.snap.core.gpf.annotations.Parameter;
 import org.esa.snap.core.gpf.annotations.SourceProduct;
 import org.esa.snap.core.gpf.annotations.TargetProduct;
 import org.esa.snap.core.util.BitSetter;

--- a/idepix-s2msi/src/main/java/org/esa/snap/idepix/s2msi/operators/cloudshadow/S2IdepixPreCloudShadowOp.java
+++ b/idepix-s2msi/src/main/java/org/esa/snap/idepix/s2msi/operators/cloudshadow/S2IdepixPreCloudShadowOp.java
@@ -51,6 +51,12 @@ public class S2IdepixPreCloudShadowOp extends Operator {
     @TargetProduct
     private Product targetProduct;
 
+    @Parameter(notNull=true)
+    private float sunZenithMean;
+
+    @Parameter(notNull=true)
+    private float sunAzimuthMean;
+
     private final static double MAX_CLOUD_HEIGHT = 8000.;
     private final static int MAX_TILE_DIMENSION_IN_M = 84000;
 
@@ -62,10 +68,6 @@ public class S2IdepixPreCloudShadowOp extends Operator {
     static int mincloudBase = 100;
     static int maxcloudTop = 10000;
     //for calculating a single cloud path
-    private float sunZenithMean;
-    private float sunAzimuthMean;
-    private float viewAzimuthMean;
-    private float viewZenithMean;
     private float minAltitude = 0;
 
     //map for the different tiles: meanReflectance per offset.
@@ -80,11 +82,6 @@ public class S2IdepixPreCloudShadowOp extends Operator {
     static int searchBorderRadius;
     private static final String sourceBandNameClusterA = "B8A";
     private static final String sourceBandNameClusterB = "B3";
-    private static final String sourceSunZenithName = "sun_zenith";
-    private static final String sourceSunAzimuthName = "sun_azimuth";
-    private static final String sourceViewAzimuthName = "view_azimuth_mean";
-    private static final String sourceViewZenithName = "view_zenith_mean";
-    private static final String sourceAltitudeName = "elevation";
     private static final String sourceFlagName1 = "pixel_classif_flags";
     private final static String BAND_NAME_CLOUD_SHADOW = "FlagBand";
 
@@ -127,35 +124,13 @@ public class S2IdepixPreCloudShadowOp extends Operator {
         sourceBandClusterA = s2ClassifProduct.getBand(sourceBandNameClusterA);
         sourceBandClusterB = s2ClassifProduct.getBand(sourceBandNameClusterB);
 
-        RasterDataNode sourceSunZenith = s2ClassifProduct.getBand(sourceSunZenithName);
-        RasterDataNode sourceSunAzimuth = s2ClassifProduct.getBand(sourceSunAzimuthName);
-        RasterDataNode sourceViewAzimuth = s2ClassifProduct.getBand(sourceViewAzimuthName);
-        RasterDataNode sourceViewZenith = s2ClassifProduct.getBand(sourceViewZenithName);
-
         final GeoPos centerGeoPos =
                 getCenterGeoPos(s2ClassifProduct.getSceneGeoCoding(), s2ClassifProduct.getSceneRasterWidth(),
                         s2ClassifProduct.getSceneRasterHeight());
         maxcloudTop = setCloudTopHeight(centerGeoPos.getLat());
 
         //create a single potential cloud path for the granule.
-        // sunZenithMean, sunAzimuthMean is the value at the central pixel.
         minAltitude = 0;
-        sunZenithMean = getRasterNodeValueAtCenter(sourceSunZenith, s2ClassifProduct.getSceneRasterWidth(),
-                s2ClassifProduct.getSceneRasterHeight());
-        sunAzimuthMean = getRasterNodeValueAtCenter(sourceSunAzimuth, s2ClassifProduct.getSceneRasterWidth(),
-                s2ClassifProduct.getSceneRasterHeight());
-        viewAzimuthMean = getRasterNodeValueAtCenter(sourceViewAzimuth, s2ClassifProduct.getSceneRasterWidth(),
-                s2ClassifProduct.getSceneRasterHeight());
-        viewZenithMean = getRasterNodeValueAtCenter(sourceViewZenith, targetProduct.getSceneRasterWidth(),
-                targetProduct.getSceneRasterHeight());
-
-        // todo: if the center pixel of the granule does not exist, find the center of the existing data!
-        // actually: sunZenith and sunAzimuth are given on the entire granule, even if the data is only partially available.
-        // view zenith and azimuth are missing, but the return value is 0 -> sunAzimuth is not corrected.
-        // this might not be the best choice for the data near the swath border, but in principal the calculation can still be done.
-
-        sunAzimuthMean = convertToApparentSunAzimuth();
-
         sourceBandFlag1 = s2ClassifProduct.getBand(sourceFlagName1);
 
         Band targetBandCloudShadow = targetProduct.addBand(BAND_NAME_CLOUD_SHADOW, ProductData.TYPE_INT32);
@@ -215,10 +190,6 @@ public class S2IdepixPreCloudShadowOp extends Operator {
         return geoCoding.getGeoPos(centerPixelPos, null);
     }
 
-    private float getRasterNodeValueAtCenter(RasterDataNode var, int width, int height) {
-        return var.getSampleFloat((int) (0.5 * width), (int) (0.5 * height));
-    }
-
     private int setCloudTopHeight(double lat) {
         return (int) Math.ceil(0.5 * Math.pow(90. - Math.abs(lat), 2.) + (90. - Math.abs(lat)) * 25 + 5000);
     }
@@ -240,21 +211,6 @@ public class S2IdepixPreCloudShadowOp extends Operator {
         int x1 = Math.min(productWidth, targetRectangle.x + targetRectangle.width + Math.max(0, Math.abs(relativeX)));
         int y1 = Math.min(productHeight, targetRectangle.y + targetRectangle.height + Math.max(0, Math.abs(relativeY)));
         return new Rectangle(x0, y0, x1 - x0, y1 - y0);
-    }
-
-    private float convertToApparentSunAzimuth() {
-        //here: cloud path is calculated for center pixel sunZenith and sunAzimuth.
-        // after correction of sun azimuth angle into apparent sun azimuth angle.
-        // Due to projection of the cloud at view_zenith>0 the position of the cloud becomes distorted.
-        // The true position still causes the shadow - and it cannot be determined without the cloud top height.
-        // So instead, the apparent sun azimuth angle is calculated and used to find the cloudShadowRelativePath.
-
-        double diff_phi = sunAzimuthMean - viewAzimuthMean;
-        if (diff_phi < 0) diff_phi = 180 + diff_phi;
-        if (diff_phi > 90) diff_phi = diff_phi - 90;
-        diff_phi = diff_phi * Math.tan(viewZenithMean * MathUtils.DTOR);
-        if (viewAzimuthMean > 180) diff_phi = -1. * diff_phi;
-        return (float) (sunAzimuthMean + diff_phi);
     }
 
     @Override

--- a/idepix-s2msi/src/main/java/org/esa/snap/idepix/s2msi/util/S2IdepixConstants.java
+++ b/idepix-s2msi/src/main/java/org/esa/snap/idepix/s2msi/util/S2IdepixConstants.java
@@ -32,7 +32,6 @@ public class S2IdepixConstants {
     public static final int NO_DATA_VALUE = -1;
 
     public static final String ELEVATION_BAND_NAME = "elevation";
-    public static final String LATITUDE_BAND_NAME = "lat";
 
     public static final String[] S2_MSI_REFLECTANCE_BAND_NAMES = {
             "B1",
@@ -57,12 +56,14 @@ public class S2IdepixConstants {
 
     public static final String SUN_ZENITH_BAND_NAME = "sun_zenith";
     public static final String SUN_AZIMUTH_BAND_NAME = "sun_azimuth";
+    public static final String VIEW_ZENITH_BAND_NAME = "view_zenith_mean";
+    public static final String VIEW_AZIMUTH_BAND_NAME = "view_azimuth_mean";
 
     public static final String[] S2_MSI_ANNOTATION_BAND_NAMES = {
             SUN_ZENITH_BAND_NAME,
-            "view_zenith_mean",
+            VIEW_ZENITH_BAND_NAME,
             SUN_AZIMUTH_BAND_NAME,
-            "view_azimuth_mean",
+            VIEW_AZIMUTH_BAND_NAME
     };
 
     public static final float[] S2_MSI_WAVELENGTHS = {


### PR DESCRIPTION
Solves https://github.com/bcdev/snap-idepix/issues/44

Solves https://github.com/bcdev/snap-idepix/issues/43 . I have changed the log level and removed the logging situation so that the logging is now done by tile, not by pixel as before.

Also, there is one more change regarding the geometries: Until now, for sun zenith, sun azimuth, view zenith and view azimuth the values were taken from the center pixel. As this might be invalid in some cases, I have added that in this case the median of the data is used. I used this rather than the mean because in some cases azimuths might have very large and very small values and a large gap between these, so the mean could actually be a completely wrong solution. 
Finally, this was computed twice, in the S2IdepixCloudShadowPreProcessOp and the S2IdepixCloudShadowPostProcessOp. I moved the computation to the S2IdepixCloudShadowOp and pass the results as parameters to the other ops.