### PR TITLE
removing endless recursion

### DIFF
--- a/idepix-landsat8/src/main/java/org/esa/snap/idepix/landsat8/Landsat8Algorithm.java
+++ b/idepix-landsat8/src/main/java/org/esa/snap/idepix/landsat8/Landsat8Algorithm.java
@@ -74,7 +74,7 @@ public class Landsat8Algorithm implements Landsat8PixelProperties {
         boolean nnCloud = nnResult[0] == NN_CATEGORY_CLOUD;
 
         // current logic: cloudSure if Shimez, Clost, Otsu or NN over water
-        return !isInvalid() && !isCloudSure() && (isCloudShimez || isCloudClost || isCloudOtsu || (nnCloud && !isLand()));
+        return !isInvalid() && (isCloudShimez || isCloudClost || isCloudOtsu || (nnCloud && !isLand()));
     }
 
     @Override


### PR DESCRIPTION
In the Landsat8 operator an endless recursion occurs:
```
Exception in thread "SunTileScheduler0Standard11" java.lang.StackOverflowError
        at org.esa.snap.idepix.landsat8.Landsat8Algorithm.isCloudSure(Landsat8Algorithm.java:77)
        at org.esa.snap.idepix.landsat8.Landsat8Algorithm.isCloudSure(Landsat8Algorithm.java:77)
        at org.esa.snap.idepix.landsat8.Landsat8Algorithm.isCloudSure(Landsat8Algorithm.java:77)
        at org.esa.snap.idepix.landsat8.Landsat8Algorithm.isCloudSure(Landsat8Algorithm.java:77)
        at org.esa.snap.idepix.landsat8.Landsat8Algorithm.isCloudSure(Landsat8Algorithm.java:77)

```

The commit simply removes the recursion.
